### PR TITLE
refactor: fastify v3 compatibility.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -26,3 +26,9 @@ node_modules/
 
 # Intellij Configuration Files
 .idea/
+
+# VSCode
+.vscode
+
+# nodenv
+.node-version

--- a/README.md
+++ b/README.md
@@ -1,14 +1,10 @@
 ## apollo-server-fastify
 
-This is a self contained version of [apollo-server-fastify], completely detatched from the [apollo-server] monorepo. It is based off of [this fork of apollo-server].
-
-It differs from the current version of [apollo-server-fastify] in the following ways:
-
-- The Fastify `reply` is now accessible within the object passed to the `config.context` function [apollographql/apollo-server#3895]
-- The usage of `beforeHandler` has been replaced with `preHandler` [apollographql/apollo-server#2391]
-  - The versions of [fastify-accepts] and [fastify-cors] have also been updated.
+This is a self contained version of [apollo-server-fastify], completely detached from the [Apollo Server] monorepo. It has been modified to be compatible with [Fastify] v3.
 
 ### Usage
+
+_*Only compatible with [Fastify] v3 or higher*_.
 
 ```shell
 npm install @autotelic/apollo-server-fastify
@@ -36,8 +32,8 @@ const app = require('fastify')();
 ```
 
 [apollo-server-fastify]: https://github.com/apollographql/apollo-server/tree/master/packages/apollo-server-fastify
-[apollo-server]: https://github.com/apollographql/apollo-server
-[this fork of apollo-server]: https://github.com/autotelic/apollo-server
+[apollo server]: https://github.com/apollographql/apollo-server
+[fastify]: https://www.fastify.io/docs/latest/
 [fastify-accepts]: https://github.com/fastify/fastify-accepts
 [fastify-cors]: https://github.com/fastify/fastify-accepts
 [apollographql/apollo-server#3895]: https://github.com/apollographql/apollo-server/pull/3895

--- a/package-lock.json
+++ b/package-lock.json
@@ -5,9 +5,9 @@
   "requires": true,
   "dependencies": {
     "@apollo/protobufjs": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/@apollo/protobufjs/-/protobufjs-1.0.3.tgz",
-      "integrity": "sha512-gqeT810Ect9WIqsrgfUvr+ljSB5m1PyBae9HGdrRyQ3HjHjTcjVvxpsMYXlUk4rUHnrfUqyoGvLSy2yLlRGEOw==",
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/@apollo/protobufjs/-/protobufjs-1.0.5.tgz",
+      "integrity": "sha512-ZtyaBH1icCgqwIGb3zrtopV2D5Q8yxibkJzlaViM08eOhTQc7rACdYu0pfORFfhllvdMZ3aq69vifYHszY4gNA==",
       "requires": {
         "@protobufjs/aspromise": "^1.1.2",
         "@protobufjs/base64": "^1.1.2",
@@ -25,24 +25,27 @@
       },
       "dependencies": {
         "@types/node": {
-          "version": "10.17.17",
-          "resolved": "https://registry.npmjs.org/@types/node/-/node-10.17.17.tgz",
-          "integrity": "sha512-gpNnRnZP3VWzzj5k3qrpRC6Rk3H/uclhAVo1aIvwzK5p5cOrs9yEyQ8H/HBsBY0u5rrWxXEiVPQ0dEB6pkjE8Q=="
+          "version": "10.17.35",
+          "resolved": "https://registry.npmjs.org/@types/node/-/node-10.17.35.tgz",
+          "integrity": "sha512-gXx7jAWpMddu0f7a+L+txMplp3FnHl53OhQIF9puXKq3hDGY/GjH+MF04oWnV/adPSCrbtHumDCFwzq2VhltWA=="
         }
       }
     },
     "@apollographql/apollo-tools": {
-      "version": "0.4.4",
-      "resolved": "https://registry.npmjs.org/@apollographql/apollo-tools/-/apollo-tools-0.4.4.tgz",
-      "integrity": "sha512-kldvB9c+vzimel4yEktlkB08gaJ5DQn9ZuIfFf1kpAw+++5hFwYRWTyKgOhF9LbOWNWGropesYC7WwLja2erhQ==",
+      "version": "0.4.8",
+      "resolved": "https://registry.npmjs.org/@apollographql/apollo-tools/-/apollo-tools-0.4.8.tgz",
+      "integrity": "sha512-W2+HB8Y7ifowcf3YyPHgDI05izyRtOeZ4MqIr7LbTArtmJ0ZHULWpn84SGMW7NAvTV1tFExpHlveHhnXuJfuGA==",
       "requires": {
-        "apollo-env": "^0.6.2"
+        "apollo-env": "^0.6.5"
       }
     },
     "@apollographql/graphql-playground-html": {
-      "version": "1.6.24",
-      "resolved": "https://registry.npmjs.org/@apollographql/graphql-playground-html/-/graphql-playground-html-1.6.24.tgz",
-      "integrity": "sha512-8GqG48m1XqyXh4mIZrtB5xOhUwSsh1WsrrsaZQOEYYql3YN9DEu9OOSg0ILzXHZo/h2Q74777YE4YzlArQzQEQ=="
+      "version": "1.6.26",
+      "resolved": "https://registry.npmjs.org/@apollographql/graphql-playground-html/-/graphql-playground-html-1.6.26.tgz",
+      "integrity": "sha512-XAwXOIab51QyhBxnxySdK3nuMEUohhDsHQ5Rbco/V1vjlP75zZ0ZLHD9dTpXTN8uxKxopb2lUvJTq+M4g2Q0HQ==",
+      "requires": {
+        "xss": "^1.0.6"
+      }
     },
     "@babel/code-frame": {
       "version": "7.8.3",
@@ -562,6 +565,13 @@
       "integrity": "sha512-jOdnI/3qTpHABjM5cx1Hc0sKsPoYCp+DP/GJRGtDlPd7fiV9oXGGIcjW/ZOxLIvjGz8MA+uMZI9metHlgqbgwQ==",
       "requires": {
         "@types/node": "*"
+      },
+      "dependencies": {
+        "@types/node": {
+          "version": "14.11.2",
+          "resolved": "https://registry.npmjs.org/@types/node/-/node-14.11.2.tgz",
+          "integrity": "sha512-jiE3QIxJ8JLNcb1Ps6rDbysDhN4xa8DJJvuC9prr6w+1tIh+QAbYyNF3tyiZNLDBIuBCf4KEcV2UvQm/V60xfA=="
+        }
       }
     },
     "@types/babel__core": {
@@ -612,6 +622,13 @@
       "requires": {
         "@types/connect": "*",
         "@types/node": "*"
+      },
+      "dependencies": {
+        "@types/node": {
+          "version": "14.11.2",
+          "resolved": "https://registry.npmjs.org/@types/node/-/node-14.11.2.tgz",
+          "integrity": "sha512-jiE3QIxJ8JLNcb1Ps6rDbysDhN4xa8DJJvuC9prr6w+1tIh+QAbYyNF3tyiZNLDBIuBCf4KEcV2UvQm/V60xfA=="
+        }
       }
     },
     "@types/color-name": {
@@ -626,6 +643,13 @@
       "integrity": "sha512-2+FrkXY4zllzTNfJth7jOqEHC+enpLeGslEhpnTAkg21GkRrWV4SsAtqchtT4YS9/nODBU2/ZfsBY2X4J/dX7A==",
       "requires": {
         "@types/node": "*"
+      },
+      "dependencies": {
+        "@types/node": {
+          "version": "14.11.2",
+          "resolved": "https://registry.npmjs.org/@types/node/-/node-14.11.2.tgz",
+          "integrity": "sha512-jiE3QIxJ8JLNcb1Ps6rDbysDhN4xa8DJJvuC9prr6w+1tIh+QAbYyNF3tyiZNLDBIuBCf4KEcV2UvQm/V60xfA=="
+        }
       }
     },
     "@types/content-disposition": {
@@ -642,6 +666,13 @@
         "@types/express": "*",
         "@types/keygrip": "*",
         "@types/node": "*"
+      },
+      "dependencies": {
+        "@types/node": {
+          "version": "14.11.2",
+          "resolved": "https://registry.npmjs.org/@types/node/-/node-14.11.2.tgz",
+          "integrity": "sha512-jiE3QIxJ8JLNcb1Ps6rDbysDhN4xa8DJJvuC9prr6w+1tIh+QAbYyNF3tyiZNLDBIuBCf4KEcV2UvQm/V60xfA=="
+        }
       }
     },
     "@types/eslint-visitor-keys": {
@@ -651,9 +682,9 @@
       "dev": true
     },
     "@types/express": {
-      "version": "4.17.6",
-      "resolved": "https://registry.npmjs.org/@types/express/-/express-4.17.6.tgz",
-      "integrity": "sha512-n/mr9tZI83kd4azlPG5y997C/M4DNABK9yErhFM6hKdym4kkmd9j0vtsJyjFIwfRBxtrxZtAfGZCNRIBMFLK5w==",
+      "version": "4.17.8",
+      "resolved": "https://registry.npmjs.org/@types/express/-/express-4.17.8.tgz",
+      "integrity": "sha512-wLhcKh3PMlyA2cNAB9sjM1BntnhPMiM0JOBwPBqttjHev2428MLEB4AYVN+d8s2iyCVZac+o41Pflm/ZH5vLXQ==",
       "requires": {
         "@types/body-parser": "*",
         "@types/express-serve-static-core": "*",
@@ -662,13 +693,20 @@
       }
     },
     "@types/express-serve-static-core": {
-      "version": "4.17.7",
-      "resolved": "https://registry.npmjs.org/@types/express-serve-static-core/-/express-serve-static-core-4.17.7.tgz",
-      "integrity": "sha512-EMgTj/DF9qpgLXyc+Btimg+XoH7A2liE8uKul8qSmMTHCeNYzydDKFdsJskDvw42UsesCnhO63dO0Grbj8J4Dw==",
+      "version": "4.17.13",
+      "resolved": "https://registry.npmjs.org/@types/express-serve-static-core/-/express-serve-static-core-4.17.13.tgz",
+      "integrity": "sha512-RgDi5a4nuzam073lRGKTUIaL3eF2+H7LJvJ8eUnCI0wA6SNjXc44DCmWNiTLs/AZ7QlsFWZiw/gTG3nSQGL0fA==",
       "requires": {
         "@types/node": "*",
         "@types/qs": "*",
         "@types/range-parser": "*"
+      },
+      "dependencies": {
+        "@types/node": {
+          "version": "14.11.2",
+          "resolved": "https://registry.npmjs.org/@types/node/-/node-14.11.2.tgz",
+          "integrity": "sha512-jiE3QIxJ8JLNcb1Ps6rDbysDhN4xa8DJJvuC9prr6w+1tIh+QAbYyNF3tyiZNLDBIuBCf4KEcV2UvQm/V60xfA=="
+        }
       }
     },
     "@types/fs-capacitor": {
@@ -677,23 +715,42 @@
       "integrity": "sha512-FKVPOCFbhCvZxpVAMhdBdTfVfXUpsh15wFHgqOKxh9N9vzWZVuWCSijZ5T4U34XYNnuj2oduh6xcs1i+LPI+BQ==",
       "requires": {
         "@types/node": "*"
+      },
+      "dependencies": {
+        "@types/node": {
+          "version": "14.11.2",
+          "resolved": "https://registry.npmjs.org/@types/node/-/node-14.11.2.tgz",
+          "integrity": "sha512-jiE3QIxJ8JLNcb1Ps6rDbysDhN4xa8DJJvuC9prr6w+1tIh+QAbYyNF3tyiZNLDBIuBCf4KEcV2UvQm/V60xfA=="
+        }
       }
     },
     "@types/graphql-upload": {
-      "version": "8.0.3",
-      "resolved": "https://registry.npmjs.org/@types/graphql-upload/-/graphql-upload-8.0.3.tgz",
-      "integrity": "sha512-hmLg9pCU/GmxBscg8GCr1vmSoEmbItNNxdD5YH2TJkXm//8atjwuprB+xJBK714JG1dkxbbhp5RHX+Pz1KsCMA==",
+      "version": "8.0.4",
+      "resolved": "https://registry.npmjs.org/@types/graphql-upload/-/graphql-upload-8.0.4.tgz",
+      "integrity": "sha512-0TRyJD2o8vbkmJF8InppFcPVcXKk+Rvlg/xvpHBIndSJYpmDWfmtx/ZAtl4f3jR2vfarpTqYgj8MZuJssSoU7Q==",
       "requires": {
         "@types/express": "*",
         "@types/fs-capacitor": "*",
         "@types/koa": "*",
-        "graphql": "^14.5.3"
+        "graphql": "^15.3.0"
+      },
+      "dependencies": {
+        "graphql": {
+          "version": "15.3.0",
+          "resolved": "https://registry.npmjs.org/graphql/-/graphql-15.3.0.tgz",
+          "integrity": "sha512-GTCJtzJmkFLWRfFJuoo9RWWa/FfamUHgiFosxi/X1Ani4AVWbeyBenZTNX6dM+7WSbbFfTo/25eh0LLkwHMw2w=="
+        }
       }
     },
     "@types/http-assert": {
       "version": "1.5.1",
       "resolved": "https://registry.npmjs.org/@types/http-assert/-/http-assert-1.5.1.tgz",
       "integrity": "sha512-PGAK759pxyfXE78NbKxyfRcWYA/KwW17X290cNev/qAsn9eQIxkH4shoNBafH37wewhDG/0p1cHPbK6+SzZjWQ=="
+    },
+    "@types/http-errors": {
+      "version": "1.8.0",
+      "resolved": "https://registry.npmjs.org/@types/http-errors/-/http-errors-1.8.0.tgz",
+      "integrity": "sha512-2aoSC4UUbHDj2uCsCxcG/vRMXey/m17bC7UwitVm5hn22nI8O8Y9iDpA76Orc+DWkQ4zZrOKEshCqR/jSuXAHA=="
     },
     "@types/istanbul-lib-coverage": {
       "version": "2.0.1",
@@ -741,17 +798,25 @@
       "integrity": "sha512-GJhpTepz2udxGexqos8wgaBx4I/zWIDPh/KOGEwAqtuGDkOUJu5eFvwmdBX4AmB8Odsr+9pHCQqiAqDL/yKMKw=="
     },
     "@types/koa": {
-      "version": "2.11.3",
-      "resolved": "https://registry.npmjs.org/@types/koa/-/koa-2.11.3.tgz",
-      "integrity": "sha512-ABxVkrNWa4O/Jp24EYI/hRNqEVRlhB9g09p48neQp4m3xL1TJtdWk2NyNQSMCU45ejeELMQZBYyfstyVvO2H3Q==",
+      "version": "2.11.4",
+      "resolved": "https://registry.npmjs.org/@types/koa/-/koa-2.11.4.tgz",
+      "integrity": "sha512-Etqs0kdqbuAsNr5k6mlZQelpZKVwMu9WPRHVVTLnceZlhr0pYmblRNJbCgoCMzKWWePldydU0AYEOX4Q9fnGUQ==",
       "requires": {
         "@types/accepts": "*",
         "@types/content-disposition": "*",
         "@types/cookies": "*",
         "@types/http-assert": "*",
+        "@types/http-errors": "*",
         "@types/keygrip": "*",
         "@types/koa-compose": "*",
         "@types/node": "*"
+      },
+      "dependencies": {
+        "@types/node": {
+          "version": "14.11.2",
+          "resolved": "https://registry.npmjs.org/@types/node/-/node-14.11.2.tgz",
+          "integrity": "sha512-jiE3QIxJ8JLNcb1Ps6rDbysDhN4xa8DJJvuC9prr6w+1tIh+QAbYyNF3tyiZNLDBIuBCf4KEcV2UvQm/V60xfA=="
+        }
       }
     },
     "@types/koa-compose": {
@@ -768,28 +833,29 @@
       "integrity": "sha512-5tXH6Bx/kNGd3MgffdmP4dy2Z+G4eaXw0SE81Tq3BNadtnMR5/ySMzX4SLEzHJzSmPNn4HIdpQsBvXMUykr58w=="
     },
     "@types/mime": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/@types/mime/-/mime-2.0.2.tgz",
-      "integrity": "sha512-4kPlzbljFcsttWEq6aBW0OZe6BDajAmyvr2xknBG92tejQnvdGtT9+kXSZ580DqpxY9qG2xeQVF9Dq0ymUTo5Q=="
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/@types/mime/-/mime-2.0.3.tgz",
+      "integrity": "sha512-Jus9s4CDbqwocc5pOAnh8ShfrnMcPHuJYzVcSUU7lrh8Ni5HuIqX3oilL86p3dlTrk0LzHRCgA/GQ7uNCw6l2Q=="
     },
     "@types/node": {
-      "version": "8.10.59",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-8.10.59.tgz",
-      "integrity": "sha512-8RkBivJrDCyPpBXhVZcjh7cQxVBSmRk9QM7hOketZzp6Tg79c0N8kkpAIito9bnJ3HCVCHVYz+KHTEbfQNfeVQ=="
+      "version": "12.12.62",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-12.12.62.tgz",
+      "integrity": "sha512-qAfo81CsD7yQIM9mVyh6B/U47li5g7cfpVQEDMfQeF8pSZVwzbhwU3crc0qG4DmpsebpJPR49AKOExQyJ05Cpg==",
+      "dev": true
     },
     "@types/node-fetch": {
-      "version": "2.5.5",
-      "resolved": "https://registry.npmjs.org/@types/node-fetch/-/node-fetch-2.5.5.tgz",
-      "integrity": "sha512-IWwjsyYjGw+em3xTvWVQi5MgYKbRs0du57klfTaZkv/B24AEQ/p/IopNeqIYNy3EsfHOpg8ieQSDomPcsYMHpA==",
+      "version": "2.5.7",
+      "resolved": "https://registry.npmjs.org/@types/node-fetch/-/node-fetch-2.5.7.tgz",
+      "integrity": "sha512-o2WVNf5UhWRkxlf6eq+jMZDu7kjgpgJfl4xVNlvryc95O/6F2ld8ztKX+qu+Rjyet93WAWm5LjeX9H5FGkODvw==",
       "requires": {
         "@types/node": "*",
         "form-data": "^3.0.0"
       },
       "dependencies": {
         "@types/node": {
-          "version": "13.9.2",
-          "resolved": "https://registry.npmjs.org/@types/node/-/node-13.9.2.tgz",
-          "integrity": "sha512-bnoqK579sAYrQbp73wwglccjJ4sfRdKU7WNEZ5FW4K2U6Kc0/eZ5kvXG0JKsEKFB50zrFmfFt52/cvBbZa7eXg=="
+          "version": "14.11.2",
+          "resolved": "https://registry.npmjs.org/@types/node/-/node-14.11.2.tgz",
+          "integrity": "sha512-jiE3QIxJ8JLNcb1Ps6rDbysDhN4xa8DJJvuC9prr6w+1tIh+QAbYyNF3tyiZNLDBIuBCf4KEcV2UvQm/V60xfA=="
         },
         "form-data": {
           "version": "3.0.0",
@@ -810,9 +876,9 @@
       "dev": true
     },
     "@types/qs": {
-      "version": "6.9.3",
-      "resolved": "https://registry.npmjs.org/@types/qs/-/qs-6.9.3.tgz",
-      "integrity": "sha512-7s9EQWupR1fTc2pSMtXRQ9w9gLOcrJn+h7HOXw4evxyvVqMi4f+q7d2tnFe3ng3SNHjtK+0EzGMGFUQX4/AQRA=="
+      "version": "6.9.5",
+      "resolved": "https://registry.npmjs.org/@types/qs/-/qs-6.9.5.tgz",
+      "integrity": "sha512-/JHkVHtx/REVG0VVToGRGH2+23hsYLHdyG+GrvoUGlGAd0ErauXDyvHtRI/7H7mzLm+tBCKA7pfcpkQ1lf58iQ=="
     },
     "@types/range-parser": {
       "version": "1.2.3",
@@ -820,9 +886,9 @@
       "integrity": "sha512-ewFXqrQHlFsgc09MK5jP5iR7vumV/BYayNC6PgJO2LPe8vrnNFyjQjSppfEngITi0qvfKtzFvgKymGheFM9UOA=="
     },
     "@types/serve-static": {
-      "version": "1.13.4",
-      "resolved": "https://registry.npmjs.org/@types/serve-static/-/serve-static-1.13.4.tgz",
-      "integrity": "sha512-jTDt0o/YbpNwZbQmE/+2e+lfjJEJJR0I3OFaKQKPWkASkCoW3i6fsUnqudSMcNAfbtmADGu8f4MV4q+GqULmug==",
+      "version": "1.13.5",
+      "resolved": "https://registry.npmjs.org/@types/serve-static/-/serve-static-1.13.5.tgz",
+      "integrity": "sha512-6M64P58N+OXjU432WoLLBQxbA0LRGBCRm7aAGQJ+SMC1IMl0dgRVi9EFfoDcS2a7Xogygk/eGN94CfwU9UF7UQ==",
       "requires": {
         "@types/express-serve-static-core": "*",
         "@types/mime": "*"
@@ -835,11 +901,18 @@
       "dev": true
     },
     "@types/ws": {
-      "version": "7.2.5",
-      "resolved": "https://registry.npmjs.org/@types/ws/-/ws-7.2.5.tgz",
-      "integrity": "sha512-4UEih9BI1nBKii385G9id1oFrSkLcClbwtDfcYj8HJLQqZVAtb/42vXVrYvRWCcufNF/a+rZD3MxNwghA7UmCg==",
+      "version": "7.2.7",
+      "resolved": "https://registry.npmjs.org/@types/ws/-/ws-7.2.7.tgz",
+      "integrity": "sha512-UUFC/xxqFLP17hTva8/lVT0SybLUrfSD9c+iapKb0fEiC8uoDbA+xuZ3pAN603eW+bY8ebSMLm9jXdIPnD0ZgA==",
       "requires": {
         "@types/node": "*"
+      },
+      "dependencies": {
+        "@types/node": {
+          "version": "14.11.2",
+          "resolved": "https://registry.npmjs.org/@types/node/-/node-14.11.2.tgz",
+          "integrity": "sha512-jiE3QIxJ8JLNcb1Ps6rDbysDhN4xa8DJJvuC9prr6w+1tIh+QAbYyNF3tyiZNLDBIuBCf4KEcV2UvQm/V60xfA=="
+        }
       }
     },
     "@types/yargs": {
@@ -1040,115 +1113,42 @@
       }
     },
     "apollo-cache-control": {
-      "version": "0.9.0",
-      "resolved": "https://registry.npmjs.org/apollo-cache-control/-/apollo-cache-control-0.9.0.tgz",
-      "integrity": "sha512-iLT6IT4Ul5cMfBcJAvhpk3a7AD6fXqvFxNmJEPVapVJHbSKYIjra4PTis13sOyN5Y3WQS6a+NRFxAW8+hL3q3Q==",
-      "dev": true,
+      "version": "0.11.3",
+      "resolved": "https://registry.npmjs.org/apollo-cache-control/-/apollo-cache-control-0.11.3.tgz",
+      "integrity": "sha512-21GCeC9AIIa22uD0Vtqn/N0D5kOB4rY/Pa9aQhxVeLN+4f8Eu4nmteXhFypUD0LL1/58dmm8lS5embsfoIGjEA==",
       "requires": {
-        "apollo-server-env": "^2.4.3",
-        "graphql-extensions": "^0.11.0"
+        "apollo-server-env": "^2.4.5",
+        "apollo-server-plugin-base": "^0.10.1"
       }
     },
     "apollo-datasource": {
-      "version": "0.7.0",
-      "resolved": "https://registry.npmjs.org/apollo-datasource/-/apollo-datasource-0.7.0.tgz",
-      "integrity": "sha512-Yja12BgNQhzuFGG/5Nw2MQe0hkuQy2+9er09HxeEyAf2rUDIPnhPrn1MDoZTB8MU7UGfjwITC+1ofzKkkrZobA==",
-      "dev": true,
+      "version": "0.7.2",
+      "resolved": "https://registry.npmjs.org/apollo-datasource/-/apollo-datasource-0.7.2.tgz",
+      "integrity": "sha512-ibnW+s4BMp4K2AgzLEtvzkjg7dJgCaw9M5b5N0YKNmeRZRnl/I/qBTQae648FsRKgMwTbRQIvBhQ0URUFAqFOw==",
       "requires": {
-        "apollo-server-caching": "^0.5.1",
-        "apollo-server-env": "^2.4.3"
+        "apollo-server-caching": "^0.5.2",
+        "apollo-server-env": "^2.4.5"
       }
     },
     "apollo-datasource-rest": {
-      "version": "0.8.0",
-      "resolved": "https://registry.npmjs.org/apollo-datasource-rest/-/apollo-datasource-rest-0.8.0.tgz",
-      "integrity": "sha512-eM/Ya4FUrKbd6+GaAPe2lIeK9/69YA8N/SIASeNlnqpox92IjQEvw8cBo/BOQccwyoA8pzxxn4soraUBiPZ8Hw==",
+      "version": "0.9.4",
+      "resolved": "https://registry.npmjs.org/apollo-datasource-rest/-/apollo-datasource-rest-0.9.4.tgz",
+      "integrity": "sha512-JBtjLsmYE+D8Vb5GPf6iRed5vIRpViifg9LVq1oSiBGc4oAhtvr07+gY89/bXU2XbznBF90AYt35j9d5881dMA==",
       "dev": true,
       "requires": {
-        "apollo-datasource": "^0.7.0",
-        "apollo-server-caching": "^0.5.1",
-        "apollo-server-env": "^2.4.3",
-        "apollo-server-errors": "^2.4.0",
+        "apollo-datasource": "^0.7.2",
+        "apollo-server-caching": "^0.5.2",
+        "apollo-server-env": "^2.4.5",
+        "apollo-server-errors": "^2.4.2",
         "http-cache-semantics": "^4.0.0"
       }
     },
-    "apollo-engine-reporting": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/apollo-engine-reporting/-/apollo-engine-reporting-2.0.0.tgz",
-      "integrity": "sha512-FvNwORsh3nxEfvQqd2xbd468a0q/R3kYar/Bk6YQdBX5qwqUhqmOcOSxLFk8Zb77HpwHij5CPpPWJb53TU1zcA==",
-      "requires": {
-        "apollo-engine-reporting-protobuf": "^0.5.1",
-        "apollo-graphql": "^0.4.0",
-        "apollo-server-caching": "^0.5.1",
-        "apollo-server-env": "^2.4.4",
-        "apollo-server-errors": "^2.4.1",
-        "apollo-server-plugin-base": "^0.9.0",
-        "apollo-server-types": "^0.5.0",
-        "async-retry": "^1.2.1",
-        "uuid": "^8.0.0"
-      },
-      "dependencies": {
-        "apollo-engine-reporting-protobuf": {
-          "version": "0.5.1",
-          "resolved": "https://registry.npmjs.org/apollo-engine-reporting-protobuf/-/apollo-engine-reporting-protobuf-0.5.1.tgz",
-          "integrity": "sha512-TSfr9iAaInV8dhXkesdcmqsthRkVcJkzznmiM+1Ob/GScK7r6hBYCjVDt2613EHAg9SUzTOltIKlGD+N+GJRUw==",
-          "requires": {
-            "@apollo/protobufjs": "^1.0.3"
-          }
-        },
-        "apollo-server-env": {
-          "version": "2.4.4",
-          "resolved": "https://registry.npmjs.org/apollo-server-env/-/apollo-server-env-2.4.4.tgz",
-          "integrity": "sha512-c2oddDS3lwAl6QNCIKCLEzt/dF9M3/tjjYRVdxOVN20TidybI7rAbnT4QOzf4tORnGXtiznEAvr/Kc9ahhKADg==",
-          "requires": {
-            "node-fetch": "^2.1.2",
-            "util.promisify": "^1.0.0"
-          }
-        },
-        "apollo-server-errors": {
-          "version": "2.4.1",
-          "resolved": "https://registry.npmjs.org/apollo-server-errors/-/apollo-server-errors-2.4.1.tgz",
-          "integrity": "sha512-7oEd6pUxqyWYUbQ9TA8tM0NU/3aGtXSEibo6+txUkuHe7QaxfZ2wHRp+pfT1LC1K3RXYjKj61/C2xEO19s3Kdg=="
-        },
-        "apollo-server-plugin-base": {
-          "version": "0.9.0",
-          "resolved": "https://registry.npmjs.org/apollo-server-plugin-base/-/apollo-server-plugin-base-0.9.0.tgz",
-          "integrity": "sha512-LWcPrsy2+xqwlNseh/QaGa/MPNopS8c4qGgh0g0cAn0lZBRrJ9Yab7dq+iQ6vdUBwIhUWYN6s9dwUWCZw2SL8g==",
-          "requires": {
-            "apollo-server-types": "^0.5.0"
-          }
-        },
-        "apollo-server-types": {
-          "version": "0.5.0",
-          "resolved": "https://registry.npmjs.org/apollo-server-types/-/apollo-server-types-0.5.0.tgz",
-          "integrity": "sha512-zhtsqqqfdeoJQAfc41Sy6WnnBVxKNgZ34BKXf/Q+kXmw7rbZ/B5SG3SJMvj1iFsbzZxILmWdUsE9aD20lEr0bg==",
-          "requires": {
-            "apollo-engine-reporting-protobuf": "^0.5.1",
-            "apollo-server-caching": "^0.5.1",
-            "apollo-server-env": "^2.4.4"
-          }
-        },
-        "uuid": {
-          "version": "8.1.0",
-          "resolved": "https://registry.npmjs.org/uuid/-/uuid-8.1.0.tgz",
-          "integrity": "sha512-CI18flHDznR0lq54xBycOVmphdCYnQLKn8abKn7PXUiKUGdEd+/l9LWNJmugXel4hXq7S+RMNl34ecyC9TntWg=="
-        }
-      }
-    },
-    "apollo-engine-reporting-protobuf": {
-      "version": "0.4.4",
-      "resolved": "https://registry.npmjs.org/apollo-engine-reporting-protobuf/-/apollo-engine-reporting-protobuf-0.4.4.tgz",
-      "integrity": "sha512-SGrIkUR7Q/VjU8YG98xcvo340C4DaNUhg/TXOtGsMlfiJDzHwVau/Bv6zifAzBafp2lj0XND6Daj5kyT/eSI/w==",
-      "requires": {
-        "@apollo/protobufjs": "^1.0.3"
-      }
-    },
     "apollo-env": {
-      "version": "0.6.2",
-      "resolved": "https://registry.npmjs.org/apollo-env/-/apollo-env-0.6.2.tgz",
-      "integrity": "sha512-Vb/doL1ZbzkNDJCQ6kYGOrphRx63rMERYo3MT2pzm2pNEdm6AK60InMgJaeh3RLK3cjGllOXFAgP8IY+m+TaEg==",
+      "version": "0.6.5",
+      "resolved": "https://registry.npmjs.org/apollo-env/-/apollo-env-0.6.5.tgz",
+      "integrity": "sha512-jeBUVsGymeTHYWp3me0R2CZRZrFeuSZeICZHCeRflHTfnQtlmbSXdy5E0pOyRM9CU4JfQkKDC98S1YglQj7Bzg==",
       "requires": {
-        "@types/node-fetch": "2.5.5",
+        "@types/node-fetch": "2.5.7",
         "core-js": "^3.0.1",
         "node-fetch": "^2.2.0",
         "sha.js": "^2.4.11"
@@ -1164,75 +1164,44 @@
       }
     },
     "apollo-graphql": {
-      "version": "0.4.4",
-      "resolved": "https://registry.npmjs.org/apollo-graphql/-/apollo-graphql-0.4.4.tgz",
-      "integrity": "sha512-i012iRKT5nfsOaNMx4MTwHw2jrlyaF1zikpejxsGHsKIf3OngGvGh3pyw20bEmwj413OrNQpRxvvIz5A7W/8xw==",
+      "version": "0.6.0",
+      "resolved": "https://registry.npmjs.org/apollo-graphql/-/apollo-graphql-0.6.0.tgz",
+      "integrity": "sha512-BxTf5LOQe649e9BNTPdyCGItVv4Ll8wZ2BKnmiYpRAocYEXAVrQPWuSr3dO4iipqAU8X0gvle/Xu9mSqg5b7Qg==",
       "requires": {
         "apollo-env": "^0.6.5",
         "lodash.sortby": "^4.7.0"
-      },
-      "dependencies": {
-        "@types/node-fetch": {
-          "version": "2.5.7",
-          "resolved": "https://registry.npmjs.org/@types/node-fetch/-/node-fetch-2.5.7.tgz",
-          "integrity": "sha512-o2WVNf5UhWRkxlf6eq+jMZDu7kjgpgJfl4xVNlvryc95O/6F2ld8ztKX+qu+Rjyet93WAWm5LjeX9H5FGkODvw==",
-          "requires": {
-            "@types/node": "*",
-            "form-data": "^3.0.0"
-          }
-        },
-        "apollo-env": {
-          "version": "0.6.5",
-          "resolved": "https://registry.npmjs.org/apollo-env/-/apollo-env-0.6.5.tgz",
-          "integrity": "sha512-jeBUVsGymeTHYWp3me0R2CZRZrFeuSZeICZHCeRflHTfnQtlmbSXdy5E0pOyRM9CU4JfQkKDC98S1YglQj7Bzg==",
-          "requires": {
-            "@types/node-fetch": "2.5.7",
-            "core-js": "^3.0.1",
-            "node-fetch": "^2.2.0",
-            "sha.js": "^2.4.11"
-          }
-        },
-        "form-data": {
-          "version": "3.0.0",
-          "resolved": "https://registry.npmjs.org/form-data/-/form-data-3.0.0.tgz",
-          "integrity": "sha512-CKMFDglpbMi6PyN+brwB9Q/GOw0eAnsrEZDgcsH5Krhz5Od/haKHAX0NmQfha2zPPz0JpWzA7GJHGSnvCRLWsg==",
-          "requires": {
-            "asynckit": "^0.4.0",
-            "combined-stream": "^1.0.8",
-            "mime-types": "^2.1.12"
-          }
-        }
       }
     },
     "apollo-link": {
-      "version": "1.2.13",
-      "resolved": "https://registry.npmjs.org/apollo-link/-/apollo-link-1.2.13.tgz",
-      "integrity": "sha512-+iBMcYeevMm1JpYgwDEIDt/y0BB7VWyvlm/7x+TIPNLHCTCMgcEgDuW5kH86iQZWo0I7mNwQiTOz+/3ShPFmBw==",
+      "version": "1.2.14",
+      "resolved": "https://registry.npmjs.org/apollo-link/-/apollo-link-1.2.14.tgz",
+      "integrity": "sha512-p67CMEFP7kOG1JZ0ZkYZwRDa369w5PIjtMjvrQd/HnIV8FRsHRqLqK+oAZQnFa1DDdZtOtHTi+aMIW6EatC2jg==",
+      "dev": true,
       "requires": {
         "apollo-utilities": "^1.3.0",
         "ts-invariant": "^0.4.0",
         "tslib": "^1.9.3",
-        "zen-observable-ts": "^0.8.20"
+        "zen-observable-ts": "^0.8.21"
       }
     },
     "apollo-link-http": {
-      "version": "1.5.16",
-      "resolved": "https://registry.npmjs.org/apollo-link-http/-/apollo-link-http-1.5.16.tgz",
-      "integrity": "sha512-IA3xA/OcrOzINRZEECI6IdhRp/Twom5X5L9jMehfzEo2AXdeRwAMlH5LuvTZHgKD8V1MBnXdM6YXawXkTDSmJw==",
+      "version": "1.5.17",
+      "resolved": "https://registry.npmjs.org/apollo-link-http/-/apollo-link-http-1.5.17.tgz",
+      "integrity": "sha512-uWcqAotbwDEU/9+Dm9e1/clO7hTB2kQ/94JYcGouBVLjoKmTeJTUPQKcJGpPwUjZcSqgYicbFqQSoJIW0yrFvg==",
       "dev": true,
       "requires": {
-        "apollo-link": "^1.2.13",
-        "apollo-link-http-common": "^0.2.15",
+        "apollo-link": "^1.2.14",
+        "apollo-link-http-common": "^0.2.16",
         "tslib": "^1.9.3"
       }
     },
     "apollo-link-http-common": {
-      "version": "0.2.15",
-      "resolved": "https://registry.npmjs.org/apollo-link-http-common/-/apollo-link-http-common-0.2.15.tgz",
-      "integrity": "sha512-+Heey4S2IPsPyTf8Ag3PugUupASJMW894iVps6hXbvwtg1aHSNMXUYO5VG7iRHkPzqpuzT4HMBanCTXPjtGzxg==",
+      "version": "0.2.16",
+      "resolved": "https://registry.npmjs.org/apollo-link-http-common/-/apollo-link-http-common-0.2.16.tgz",
+      "integrity": "sha512-2tIhOIrnaF4UbQHf7kjeQA/EmSorB7+HyJIIrUjJOKBgnXwuexi8aMecRlqTIDWcyVXCeqLhUnztMa6bOH/jTg==",
       "dev": true,
       "requires": {
-        "apollo-link": "^1.2.13",
+        "apollo-link": "^1.2.14",
         "ts-invariant": "^0.4.0",
         "tslib": "^1.9.3"
       }
@@ -1247,202 +1216,111 @@
         "hash.js": "^1.1.3"
       }
     },
+    "apollo-reporting-protobuf": {
+      "version": "0.6.0",
+      "resolved": "https://registry.npmjs.org/apollo-reporting-protobuf/-/apollo-reporting-protobuf-0.6.0.tgz",
+      "integrity": "sha512-AFLQIuO0QhkoCF+41Be/B/YU0C33BZ0opfyXorIjM3MNNiEDSyjZqmUozlB3LqgfhT9mn2IR5RSsA+1b4VovDQ==",
+      "requires": {
+        "@apollo/protobufjs": "^1.0.3"
+      }
+    },
     "apollo-server-caching": {
-      "version": "0.5.1",
-      "resolved": "https://registry.npmjs.org/apollo-server-caching/-/apollo-server-caching-0.5.1.tgz",
-      "integrity": "sha512-L7LHZ3k9Ao5OSf2WStvQhxdsNVplRQi7kCAPfqf9Z3GBEnQ2uaL0EgO0hSmtVHfXTbk5CTRziMT1Pe87bXrFIw==",
+      "version": "0.5.2",
+      "resolved": "https://registry.npmjs.org/apollo-server-caching/-/apollo-server-caching-0.5.2.tgz",
+      "integrity": "sha512-HUcP3TlgRsuGgeTOn8QMbkdx0hLPXyEJehZIPrcof0ATz7j7aTPA4at7gaiFHCo8gk07DaWYGB3PFgjboXRcWQ==",
       "requires": {
         "lru-cache": "^5.0.0"
       }
     },
     "apollo-server-core": {
-      "version": "2.14.2",
-      "resolved": "https://registry.npmjs.org/apollo-server-core/-/apollo-server-core-2.14.2.tgz",
-      "integrity": "sha512-8G6Aoz+k+ecuQco1KNLFbMrxhe/8uR4AOaOYEvT/N5m/6lrkPYzvBAxbpRIub5AxEwpBPcIrI452rR3PD9DItA==",
+      "version": "2.18.1",
+      "resolved": "https://registry.npmjs.org/apollo-server-core/-/apollo-server-core-2.18.1.tgz",
+      "integrity": "sha512-Bv08AyJ3WSms59loE31haVRBctDn6MGyjtaPnfLlQV5//wMdwS5MXX8RcMCmXxv0Utp5TlhoD+pHLO5Ool+LRw==",
       "requires": {
         "@apollographql/apollo-tools": "^0.4.3",
-        "@apollographql/graphql-playground-html": "1.6.24",
+        "@apollographql/graphql-playground-html": "1.6.26",
         "@types/graphql-upload": "^8.0.0",
         "@types/ws": "^7.0.0",
-        "apollo-cache-control": "^0.11.0",
-        "apollo-datasource": "^0.7.1",
-        "apollo-engine-reporting": "^2.0.0",
-        "apollo-server-caching": "^0.5.1",
-        "apollo-server-env": "^2.4.4",
-        "apollo-server-errors": "^2.4.1",
-        "apollo-server-plugin-base": "^0.9.0",
-        "apollo-server-types": "^0.5.0",
-        "apollo-tracing": "^0.11.0",
+        "apollo-cache-control": "^0.11.3",
+        "apollo-datasource": "^0.7.2",
+        "apollo-graphql": "^0.6.0",
+        "apollo-reporting-protobuf": "^0.6.0",
+        "apollo-server-caching": "^0.5.2",
+        "apollo-server-env": "^2.4.5",
+        "apollo-server-errors": "^2.4.2",
+        "apollo-server-plugin-base": "^0.10.1",
+        "apollo-server-types": "^0.6.0",
+        "apollo-tracing": "^0.11.4",
+        "async-retry": "^1.2.1",
         "fast-json-stable-stringify": "^2.0.0",
-        "graphql-extensions": "^0.12.2",
+        "graphql-extensions": "^0.12.5",
         "graphql-tag": "^2.9.2",
         "graphql-tools": "^4.0.0",
         "graphql-upload": "^8.0.2",
         "loglevel": "^1.6.7",
         "sha.js": "^2.4.11",
         "subscriptions-transport-ws": "^0.9.11",
+        "uuid": "^8.0.0",
         "ws": "^6.0.0"
       },
       "dependencies": {
-        "apollo-cache-control": {
-          "version": "0.11.0",
-          "resolved": "https://registry.npmjs.org/apollo-cache-control/-/apollo-cache-control-0.11.0.tgz",
-          "integrity": "sha512-dmRnQ9AXGw2SHahVGLzB/p4UW/taFBAJxifxubp8hqY5p9qdlSu4MPRq8zvV2ULMYf50rBtZyC4C+dZLqmHuHQ==",
-          "requires": {
-            "apollo-server-env": "^2.4.4",
-            "apollo-server-plugin-base": "^0.9.0"
-          }
-        },
-        "apollo-datasource": {
-          "version": "0.7.1",
-          "resolved": "https://registry.npmjs.org/apollo-datasource/-/apollo-datasource-0.7.1.tgz",
-          "integrity": "sha512-h++/jQAY7GA+4TBM+7ezvctFmmGNLrAPf51KsagZj+NkT9qvxp585rdsuatynVbSl59toPK2EuVmc6ilmQHf+g==",
-          "requires": {
-            "apollo-server-caching": "^0.5.1",
-            "apollo-server-env": "^2.4.4"
-          }
-        },
-        "apollo-engine-reporting-protobuf": {
-          "version": "0.5.1",
-          "resolved": "https://registry.npmjs.org/apollo-engine-reporting-protobuf/-/apollo-engine-reporting-protobuf-0.5.1.tgz",
-          "integrity": "sha512-TSfr9iAaInV8dhXkesdcmqsthRkVcJkzznmiM+1Ob/GScK7r6hBYCjVDt2613EHAg9SUzTOltIKlGD+N+GJRUw==",
-          "requires": {
-            "@apollo/protobufjs": "^1.0.3"
-          }
-        },
-        "apollo-server-env": {
-          "version": "2.4.4",
-          "resolved": "https://registry.npmjs.org/apollo-server-env/-/apollo-server-env-2.4.4.tgz",
-          "integrity": "sha512-c2oddDS3lwAl6QNCIKCLEzt/dF9M3/tjjYRVdxOVN20TidybI7rAbnT4QOzf4tORnGXtiznEAvr/Kc9ahhKADg==",
-          "requires": {
-            "node-fetch": "^2.1.2",
-            "util.promisify": "^1.0.0"
-          }
-        },
-        "apollo-server-errors": {
-          "version": "2.4.1",
-          "resolved": "https://registry.npmjs.org/apollo-server-errors/-/apollo-server-errors-2.4.1.tgz",
-          "integrity": "sha512-7oEd6pUxqyWYUbQ9TA8tM0NU/3aGtXSEibo6+txUkuHe7QaxfZ2wHRp+pfT1LC1K3RXYjKj61/C2xEO19s3Kdg=="
-        },
-        "apollo-server-plugin-base": {
-          "version": "0.9.0",
-          "resolved": "https://registry.npmjs.org/apollo-server-plugin-base/-/apollo-server-plugin-base-0.9.0.tgz",
-          "integrity": "sha512-LWcPrsy2+xqwlNseh/QaGa/MPNopS8c4qGgh0g0cAn0lZBRrJ9Yab7dq+iQ6vdUBwIhUWYN6s9dwUWCZw2SL8g==",
-          "requires": {
-            "apollo-server-types": "^0.5.0"
-          }
-        },
-        "apollo-server-types": {
-          "version": "0.5.0",
-          "resolved": "https://registry.npmjs.org/apollo-server-types/-/apollo-server-types-0.5.0.tgz",
-          "integrity": "sha512-zhtsqqqfdeoJQAfc41Sy6WnnBVxKNgZ34BKXf/Q+kXmw7rbZ/B5SG3SJMvj1iFsbzZxILmWdUsE9aD20lEr0bg==",
-          "requires": {
-            "apollo-engine-reporting-protobuf": "^0.5.1",
-            "apollo-server-caching": "^0.5.1",
-            "apollo-server-env": "^2.4.4"
-          }
-        },
-        "graphql-extensions": {
-          "version": "0.12.2",
-          "resolved": "https://registry.npmjs.org/graphql-extensions/-/graphql-extensions-0.12.2.tgz",
-          "integrity": "sha512-vFaZua5aLiCOOzxfY5qzHZ6S52BCqW7VVOwzvV52Wb5edRm3dn6u+1MR9yYyEqUHSf8LvdhEojYlOkKiaQ4ghA==",
-          "requires": {
-            "@apollographql/apollo-tools": "^0.4.3",
-            "apollo-server-env": "^2.4.4",
-            "apollo-server-types": "^0.5.0"
-          }
+        "uuid": {
+          "version": "8.3.0",
+          "resolved": "https://registry.npmjs.org/uuid/-/uuid-8.3.0.tgz",
+          "integrity": "sha512-fX6Z5o4m6XsXBdli9g7DtWgAx+osMsRRZFKma1mIUsLCz6vRvv+pz5VNbyu9UEDzpMWulZfvpgb/cmDXVulYFQ=="
         }
       }
     },
     "apollo-server-env": {
-      "version": "2.4.3",
-      "resolved": "https://registry.npmjs.org/apollo-server-env/-/apollo-server-env-2.4.3.tgz",
-      "integrity": "sha512-23R5Xo9OMYX0iyTu2/qT0EUb+AULCBriA9w8HDfMoChB8M+lFClqUkYtaTTHDfp6eoARLW8kDBhPOBavsvKAjA==",
+      "version": "2.4.5",
+      "resolved": "https://registry.npmjs.org/apollo-server-env/-/apollo-server-env-2.4.5.tgz",
+      "integrity": "sha512-nfNhmGPzbq3xCEWT8eRpoHXIPNcNy3QcEoBlzVMjeglrBGryLG2LXwBSPnVmTRRrzUYugX0ULBtgE3rBFNoUgA==",
       "requires": {
         "node-fetch": "^2.1.2",
         "util.promisify": "^1.0.0"
       }
     },
     "apollo-server-errors": {
-      "version": "2.4.0",
-      "resolved": "https://registry.npmjs.org/apollo-server-errors/-/apollo-server-errors-2.4.0.tgz",
-      "integrity": "sha512-ZouZfr2sGavvI18rgdRcyY2ausRAlVtWNOax9zca8ZG2io86dM59jXBmUVSNlVZSmBsIh45YxYC0eRvr2vmRdg==",
-      "dev": true
+      "version": "2.4.2",
+      "resolved": "https://registry.npmjs.org/apollo-server-errors/-/apollo-server-errors-2.4.2.tgz",
+      "integrity": "sha512-FeGxW3Batn6sUtX3OVVUm7o56EgjxDlmgpTLNyWcLb0j6P8mw9oLNyAm3B+deHA4KNdNHO5BmHS2g1SJYjqPCQ=="
     },
     "apollo-server-plugin-base": {
-      "version": "0.7.0",
-      "resolved": "https://registry.npmjs.org/apollo-server-plugin-base/-/apollo-server-plugin-base-0.7.0.tgz",
-      "integrity": "sha512-//xgYrBYLQSr92W0z3mYsFGoVz3wxKNsv3KcOUBhbOCGTbjZgP7vHOE1vhHhRcpZKKXmjXTVONdrnNJ+XVGi6A==",
-      "dev": true,
+      "version": "0.10.1",
+      "resolved": "https://registry.npmjs.org/apollo-server-plugin-base/-/apollo-server-plugin-base-0.10.1.tgz",
+      "integrity": "sha512-XChCBDNyfByWqVXptsjPwrwrCj5cxMmNbchZZi8KXjtJ0hN2C/9BMNlInJd6bVGXvUbkRJYUakfKCfO5dZmwIg==",
       "requires": {
-        "apollo-server-types": "^0.3.0"
+        "apollo-server-types": "^0.6.0"
       }
     },
     "apollo-server-plugin-response-cache": {
-      "version": "0.4.0",
-      "resolved": "https://registry.npmjs.org/apollo-server-plugin-response-cache/-/apollo-server-plugin-response-cache-0.4.0.tgz",
-      "integrity": "sha512-6yetQNBlGDGNXdgv+0z9eRoPMWkQA6fG+cv1hB2Ekz3Xt0FOobCmDPKzd7yjVg28J1Y5in2QPXCkkiCWARxwGA==",
+      "version": "0.5.5",
+      "resolved": "https://registry.npmjs.org/apollo-server-plugin-response-cache/-/apollo-server-plugin-response-cache-0.5.5.tgz",
+      "integrity": "sha512-2rQv74kqRDmQ+ugVzm+lIXtZXMZSOIJpx9ChFA/J1o+W2qZUt3BBxx0Xy8FGxTEF/FkepIXbv/Z7jl6MJrmUsA==",
       "dev": true,
       "requires": {
-        "apollo-cache-control": "^0.9.0",
-        "apollo-server-caching": "^0.5.1",
-        "apollo-server-plugin-base": "^0.7.0"
+        "apollo-cache-control": "^0.11.3",
+        "apollo-server-caching": "^0.5.2",
+        "apollo-server-plugin-base": "^0.10.1"
       }
     },
     "apollo-server-types": {
-      "version": "0.3.0",
-      "resolved": "https://registry.npmjs.org/apollo-server-types/-/apollo-server-types-0.3.0.tgz",
-      "integrity": "sha512-FMo7kbTkhph9dfIQ3xDbRLObqmdQH9mwSjxhGsX+JxGMRPPXgd3+GZvCeVKOi/udxh//w1otSeAqItjvbj0tfQ==",
+      "version": "0.6.0",
+      "resolved": "https://registry.npmjs.org/apollo-server-types/-/apollo-server-types-0.6.0.tgz",
+      "integrity": "sha512-usqXaz81bHxD2IZvKEQNnLpSbf2Z/BmobXZAjEefJEQv1ItNn+lJNUmSSEfGejHvHlg2A7WuAJKJWyDWcJrNnA==",
       "requires": {
-        "apollo-engine-reporting-protobuf": "^0.4.4",
-        "apollo-server-caching": "^0.5.1",
-        "apollo-server-env": "^2.4.3"
+        "apollo-reporting-protobuf": "^0.6.0",
+        "apollo-server-caching": "^0.5.2",
+        "apollo-server-env": "^2.4.5"
       }
     },
     "apollo-tracing": {
-      "version": "0.11.0",
-      "resolved": "https://registry.npmjs.org/apollo-tracing/-/apollo-tracing-0.11.0.tgz",
-      "integrity": "sha512-I9IFb/8lkBW8ZwOAi4LEojfT7dMfUSkpnV8LHQI8Rcj0HtzL9HObQ3woBmzyGHdGHLFuD/6/VHyFD67SesSrJg==",
+      "version": "0.11.4",
+      "resolved": "https://registry.npmjs.org/apollo-tracing/-/apollo-tracing-0.11.4.tgz",
+      "integrity": "sha512-zBu/SwQlXfbdpcKLzWARGVjrEkIZUW3W9Mb4CCIzv07HbBQ8IQpmf9w7HIJJefC7rBiBJYg6JBGyuro3N2lxCA==",
       "requires": {
-        "apollo-server-env": "^2.4.4",
-        "apollo-server-plugin-base": "^0.9.0"
-      },
-      "dependencies": {
-        "apollo-engine-reporting-protobuf": {
-          "version": "0.5.1",
-          "resolved": "https://registry.npmjs.org/apollo-engine-reporting-protobuf/-/apollo-engine-reporting-protobuf-0.5.1.tgz",
-          "integrity": "sha512-TSfr9iAaInV8dhXkesdcmqsthRkVcJkzznmiM+1Ob/GScK7r6hBYCjVDt2613EHAg9SUzTOltIKlGD+N+GJRUw==",
-          "requires": {
-            "@apollo/protobufjs": "^1.0.3"
-          }
-        },
-        "apollo-server-env": {
-          "version": "2.4.4",
-          "resolved": "https://registry.npmjs.org/apollo-server-env/-/apollo-server-env-2.4.4.tgz",
-          "integrity": "sha512-c2oddDS3lwAl6QNCIKCLEzt/dF9M3/tjjYRVdxOVN20TidybI7rAbnT4QOzf4tORnGXtiznEAvr/Kc9ahhKADg==",
-          "requires": {
-            "node-fetch": "^2.1.2",
-            "util.promisify": "^1.0.0"
-          }
-        },
-        "apollo-server-plugin-base": {
-          "version": "0.9.0",
-          "resolved": "https://registry.npmjs.org/apollo-server-plugin-base/-/apollo-server-plugin-base-0.9.0.tgz",
-          "integrity": "sha512-LWcPrsy2+xqwlNseh/QaGa/MPNopS8c4qGgh0g0cAn0lZBRrJ9Yab7dq+iQ6vdUBwIhUWYN6s9dwUWCZw2SL8g==",
-          "requires": {
-            "apollo-server-types": "^0.5.0"
-          }
-        },
-        "apollo-server-types": {
-          "version": "0.5.0",
-          "resolved": "https://registry.npmjs.org/apollo-server-types/-/apollo-server-types-0.5.0.tgz",
-          "integrity": "sha512-zhtsqqqfdeoJQAfc41Sy6WnnBVxKNgZ34BKXf/Q+kXmw7rbZ/B5SG3SJMvj1iFsbzZxILmWdUsE9aD20lEr0bg==",
-          "requires": {
-            "apollo-engine-reporting-protobuf": "^0.5.1",
-            "apollo-server-caching": "^0.5.1",
-            "apollo-server-env": "^2.4.4"
-          }
-        }
+        "apollo-server-env": "^2.4.5",
+        "apollo-server-plugin-base": "^0.10.1"
       }
     },
     "apollo-utilities": {
@@ -1565,23 +1443,24 @@
       "dev": true
     },
     "avvio": {
-      "version": "6.5.0",
-      "resolved": "https://registry.npmjs.org/avvio/-/avvio-6.5.0.tgz",
-      "integrity": "sha512-BmzcZ7gFpyFJsW8G+tfQw8vJNUboA9SDkkHLZ9RAALhvw/rplfWwni8Ee1rA11zj/J7/E5EvZmweusVvTHjWCA==",
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/avvio/-/avvio-7.2.0.tgz",
+      "integrity": "sha512-KtC63UyZARidAoIV8wXutAZnDIbZcXBqLjTAhZOX+mdMZBQCh5il/15MvCvma1178nhTwvN2D0TOAdiKG1MpUA==",
       "dev": true,
       "requires": {
         "archy": "^1.0.0",
         "debug": "^4.0.0",
-        "fastq": "^1.6.0"
+        "fastq": "^1.6.1",
+        "queue-microtask": "^1.1.2"
       },
       "dependencies": {
         "debug": {
-          "version": "4.1.1",
-          "resolved": "https://registry.npmjs.org/debug/-/debug-4.1.1.tgz",
-          "integrity": "sha512-pYAIzeRo8J6KPEaJ0VWOh5Pzkbw/RetuzehGM7QRRX5he4fPHx2rdKMB256ehJCkX+XRQm16eZLqLNS8RSZXZw==",
+          "version": "4.2.0",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-4.2.0.tgz",
+          "integrity": "sha512-IX2ncY78vDTjZMFUdmsvIRFY2Cf4FnD0wRs+nQwJU8Lu99/tPFdb0VybiiMTPe3I6rQmwsqQqRBvxU+bZ/I8sg==",
           "dev": true,
           "requires": {
-            "ms": "^2.1.1"
+            "ms": "2.1.2"
           }
         }
       }
@@ -2192,9 +2071,9 @@
       "dev": true
     },
     "core-js": {
-      "version": "3.6.4",
-      "resolved": "https://registry.npmjs.org/core-js/-/core-js-3.6.4.tgz",
-      "integrity": "sha512-4paDGScNgZP2IXXilaffL9X7968RuvwlkK3xWtZRVqgd8SYNiVKRJvkFd1aqqEuPfN7E68ZHEp9hDj6lHj4Hyw=="
+      "version": "3.6.5",
+      "resolved": "https://registry.npmjs.org/core-js/-/core-js-3.6.5.tgz",
+      "integrity": "sha512-vZVEEwZoIsI+vPEuoF9Iqf5H7/M3eeQqWlQnYa8FSKKePuYTf5MWnxb5SDAzCa60b3JBRS5g9b+Dq7b1y/RCrA=="
     },
     "core-util-is": {
       "version": "1.0.2",
@@ -2269,6 +2148,11 @@
         "shebang-command": "^1.2.0",
         "which": "^1.2.9"
       }
+    },
+    "cssfilter": {
+      "version": "0.0.10",
+      "resolved": "https://registry.npmjs.org/cssfilter/-/cssfilter-0.0.10.tgz",
+      "integrity": "sha1-xtJnJjKi5cg+AT5oZKQs6N79IK4="
     },
     "cssom": {
       "version": "0.3.8",
@@ -2360,8 +2244,7 @@
     "deepmerge": {
       "version": "4.2.2",
       "resolved": "https://registry.npmjs.org/deepmerge/-/deepmerge-4.2.2.tgz",
-      "integrity": "sha512-FJ3UgI4gIl+PHZm53knsuSFpE+nESMr7M4v9QcgB7S63Kj/6WqMiFQJpBBYz1Pt+66bZpP3Q7Lye0Oo9MPKEdg==",
-      "dev": true
+      "integrity": "sha512-FJ3UgI4gIl+PHZm53knsuSFpE+nESMr7M4v9QcgB7S63Kj/6WqMiFQJpBBYz1Pt+66bZpP3Q7Lye0Oo9MPKEdg=="
     },
     "define-properties": {
       "version": "1.1.3",
@@ -2518,7 +2401,6 @@
       "version": "1.4.4",
       "resolved": "https://registry.npmjs.org/end-of-stream/-/end-of-stream-1.4.4.tgz",
       "integrity": "sha512-+uw1inIHVPQoaVuHzRyXd21icM+cnt4CzD5rW+NC1wjOUSTOs+Te7FOv7AhN7vS9x/oIyhLP5PR1H+phQAHu5Q==",
-      "dev": true,
       "requires": {
         "once": "^1.4.0"
       }
@@ -3091,9 +2973,9 @@
       "integrity": "sha512-lhd/wF+Lk98HZoTCtlVraHtfh5XYijIjalXck7saUtuanSDyLMxnHhSXEDJqHxD7msR8D0uCmqlkwjCV8xvwHw=="
     },
     "fast-json-stringify": {
-      "version": "1.21.0",
-      "resolved": "https://registry.npmjs.org/fast-json-stringify/-/fast-json-stringify-1.21.0.tgz",
-      "integrity": "sha512-xY6gyjmHN3AK1Y15BCbMpeO9+dea5ePVsp3BouHCdukcx0hOHbXwFhRodhcI0NpZIgDChSeAKkHW9YjKvhwKBA==",
+      "version": "2.2.7",
+      "resolved": "https://registry.npmjs.org/fast-json-stringify/-/fast-json-stringify-2.2.7.tgz",
+      "integrity": "sha512-XVCR/dQ6unMP7c39XUdnPoYPPnf1RqTZGL2mAnmrXDIkyF5MRJYd87nfCEmxrqhj7k61Yi35Aaeb2QlJlZU9fg==",
       "dev": true,
       "requires": {
         "ajv": "^6.11.0",
@@ -3120,59 +3002,106 @@
       "dev": true
     },
     "fastify": {
-      "version": "2.15.1",
-      "resolved": "https://registry.npmjs.org/fastify/-/fastify-2.15.1.tgz",
-      "integrity": "sha512-pEE1pa5j/vtZeZTbPpFgsJgzLbThcYgiLDw2yZIG8qNZ5LkF1Ew2vbv9k3nTXNxGEPYFBbyNTCKRSj3JbX+FhA==",
+      "version": "3.5.0",
+      "resolved": "https://registry.npmjs.org/fastify/-/fastify-3.5.0.tgz",
+      "integrity": "sha512-wTd2l3Ndz8LSHBJG4zIwroJfgBdwHN/nilqraDy0GOnhWaCAbtTHaHb8xE6+wn1zPRDnYvmfn1/jStjqTU6UfA==",
       "dev": true,
       "requires": {
         "abstract-logging": "^2.0.0",
-        "ajv": "^6.12.0",
-        "avvio": "^6.4.1",
-        "fast-json-stringify": "^1.18.0",
-        "find-my-way": "^2.2.2",
+        "ajv": "^6.12.2",
+        "avvio": "^7.1.2",
+        "fast-json-stringify": "^2.2.1",
+        "fastify-error": "^0.2.0",
+        "fastify-warning": "^0.2.0",
+        "find-my-way": "^3.0.0",
         "flatstr": "^1.0.12",
-        "light-my-request": "^3.7.3",
-        "middie": "^4.1.0",
-        "pino": "^5.17.0",
-        "proxy-addr": "^2.0.6",
-        "readable-stream": "^3.6.0",
-        "rfdc": "^1.1.2",
-        "secure-json-parse": "^2.1.0",
-        "tiny-lru": "^7.0.2"
+        "light-my-request": "^4.0.2",
+        "pino": "^6.2.1",
+        "proxy-addr": "^2.0.5",
+        "readable-stream": "^3.4.0",
+        "rfdc": "^1.1.4",
+        "secure-json-parse": "^2.0.0",
+        "semver": "^7.3.2",
+        "tiny-lru": "^7.0.0"
+      },
+      "dependencies": {
+        "ajv": {
+          "version": "6.12.5",
+          "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.12.5.tgz",
+          "integrity": "sha512-lRF8RORchjpKG50/WFf8xmg7sgCLFiYNNnqdKflk63whMQcWR5ngGjiSXkL9bjxy6B2npOK2HSMN49jEBMSkag==",
+          "dev": true,
+          "requires": {
+            "fast-deep-equal": "^3.1.1",
+            "fast-json-stable-stringify": "^2.0.0",
+            "json-schema-traverse": "^0.4.1",
+            "uri-js": "^4.2.2"
+          }
+        },
+        "semver": {
+          "version": "7.3.2",
+          "resolved": "https://registry.npmjs.org/semver/-/semver-7.3.2.tgz",
+          "integrity": "sha512-OrOb32TeeambH6UrhtShmF7CRDqhL6/5XpPNp2DuRH6+9QLw/orhp72j87v8Qa1ScDkvrrBNpZcDejAirJmfXQ==",
+          "dev": true
+        }
       }
     },
     "fastify-accepts": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/fastify-accepts/-/fastify-accepts-1.0.0.tgz",
-      "integrity": "sha512-JVI/zKXjVfwIAdXDZvNKM7CCEWkbTFSZQUEQxrH4KBprbopGxq3R4RSIsVxqhdkVanm90yyVcPtgEa2MnDwPyg==",
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/fastify-accepts/-/fastify-accepts-2.0.1.tgz",
+      "integrity": "sha512-L7yOz/NQ4WMd6RP3eDz1bEBDXRT0Xw7ij8cNUhIw5IwDnKxnpPiX8NZd4HU+N28GEK+X5V3OrbRSYXM1upWdDg==",
       "requires": {
         "accepts": "^1.3.5",
-        "fastify-plugin": "^1.2.0"
+        "fastify-plugin": "^2.0.0"
       }
     },
     "fastify-cors": {
-      "version": "3.0.3",
-      "resolved": "https://registry.npmjs.org/fastify-cors/-/fastify-cors-3.0.3.tgz",
-      "integrity": "sha512-SDMa+GtyTTAU7pWZwY4fukb/VwCZ4c30p0oEaE7/d/+VCvceB1+NzW2udp2dSZZfWR7J1kUookCpw2dLmtAsSw==",
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/fastify-cors/-/fastify-cors-4.1.0.tgz",
+      "integrity": "sha512-Vr4AgypDkRwG16cs1ORnYItZx6FMN+gCpHvP3/nzNZL1HFzf7U/NaSgmC784VqtK8yiqSXZEoTGCsmzeSp8JVw==",
       "requires": {
-        "fastify-plugin": "^1.6.0",
+        "fastify-plugin": "^2.0.0",
         "vary": "^1.1.2"
       }
     },
-    "fastify-plugin": {
-      "version": "1.6.1",
-      "resolved": "https://registry.npmjs.org/fastify-plugin/-/fastify-plugin-1.6.1.tgz",
-      "integrity": "sha512-APBcb27s+MjaBIerFirYmBLatoPCgmHZM6XP0K+nDL9k0yX8NJPWDY1RAC3bh6z+AB5ULS2j31BUfLMT3uaZ4A==",
+    "fastify-error": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/fastify-error/-/fastify-error-0.2.0.tgz",
+      "integrity": "sha512-zabxsBatj59ROG0fhP36zNdc5Q1/eYeH9oSF9uvfrurZf8/JKfrJbMcIGrLpLWcf89rS6L91RHWm20A/X85hcA=="
+    },
+    "fastify-multipart": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/fastify-multipart/-/fastify-multipart-3.2.0.tgz",
+      "integrity": "sha512-jv+FNiFJF+F8XnlWPHq1VUQhVYbOJ1xWsqqD1cdToJg4MXxRN2D/owj1qwInhloyI6KTWpS1DTZ4tPXg4al+FA==",
       "requires": {
-        "semver": "^6.3.0"
+        "busboy": "^0.3.1",
+        "deepmerge": "^4.2.2",
+        "end-of-stream": "^1.4.4",
+        "fastify-error": "^0.2.0",
+        "fastify-plugin": "^2.3.2",
+        "hexoid": "^1.0.0",
+        "stream-wormhole": "^1.1.0"
+      }
+    },
+    "fastify-plugin": {
+      "version": "2.3.4",
+      "resolved": "https://registry.npmjs.org/fastify-plugin/-/fastify-plugin-2.3.4.tgz",
+      "integrity": "sha512-I+Oaj6p9oiRozbam30sh39BiuiqBda7yK2nmSPVwDCfIBlKnT8YB3MY+pRQc2Fcd07bf6KPGklHJaQ2Qu81TYQ==",
+      "requires": {
+        "semver": "^7.3.2"
       },
       "dependencies": {
         "semver": {
-          "version": "6.3.0",
-          "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.0.tgz",
-          "integrity": "sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw=="
+          "version": "7.3.2",
+          "resolved": "https://registry.npmjs.org/semver/-/semver-7.3.2.tgz",
+          "integrity": "sha512-OrOb32TeeambH6UrhtShmF7CRDqhL6/5XpPNp2DuRH6+9QLw/orhp72j87v8Qa1ScDkvrrBNpZcDejAirJmfXQ=="
         }
       }
+    },
+    "fastify-warning": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/fastify-warning/-/fastify-warning-0.2.0.tgz",
+      "integrity": "sha512-s1EQguBw/9qtc1p/WTY4eq9WMRIACkj+HTcOIK1in4MV5aFaQC9ZCIt0dJ7pr5bIf4lPpHvAtP2ywpTNgs7hqw==",
+      "dev": true
     },
     "fastq": {
       "version": "1.8.0",
@@ -3273,12 +3202,12 @@
       }
     },
     "find-my-way": {
-      "version": "2.2.3",
-      "resolved": "https://registry.npmjs.org/find-my-way/-/find-my-way-2.2.3.tgz",
-      "integrity": "sha512-C7dxfbX8pV1maLd31ygkBEOaD51Ls4dROuHjeSQZf1FeQinUzq3UA/kSPecLSDy9iAQufd8w1zgp7j64kyLdhw==",
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/find-my-way/-/find-my-way-3.0.4.tgz",
+      "integrity": "sha512-Trl/mNAVvTgCpo9ox6yixkwiZUvecKYUQZoAuMCBACsgGqv+FbWe+jE5sBA5+U8LIWrJk/cw8zPV53GPrjTnsw==",
       "dev": true,
       "requires": {
-        "fast-decode-uri-component": "^1.0.0",
+        "fast-decode-uri-component": "^1.0.1",
         "safe-regex2": "^2.0.0",
         "semver-store": "^0.3.0"
       }
@@ -3348,13 +3277,13 @@
       "dev": true
     },
     "form-data": {
-      "version": "2.5.1",
-      "resolved": "https://registry.npmjs.org/form-data/-/form-data-2.5.1.tgz",
-      "integrity": "sha512-m21N3WOmEEURgk6B9GLOE4RuWOFf28Lhh9qGYeNlGq4VDXUlJy2th2slBNU8Gp8EzloYZOibZJ7t5ecIrFSjVA==",
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/form-data/-/form-data-3.0.0.tgz",
+      "integrity": "sha512-CKMFDglpbMi6PyN+brwB9Q/GOw0eAnsrEZDgcsH5Krhz5Od/haKHAX0NmQfha2zPPz0JpWzA7GJHGSnvCRLWsg==",
       "dev": true,
       "requires": {
         "asynckit": "^0.4.0",
-        "combined-stream": "^1.0.6",
+        "combined-stream": "^1.0.8",
         "mime-types": "^2.1.12"
       }
     },
@@ -4042,22 +3971,22 @@
       "dev": true
     },
     "graphql": {
-      "version": "14.6.0",
-      "resolved": "https://registry.npmjs.org/graphql/-/graphql-14.6.0.tgz",
-      "integrity": "sha512-VKzfvHEKybTKjQVpTFrA5yUq2S9ihcZvfJAtsDBBCuV6wauPu1xl/f9ehgVf0FcEJJs4vz6ysb/ZMkGigQZseg==",
+      "version": "14.7.0",
+      "resolved": "https://registry.npmjs.org/graphql/-/graphql-14.7.0.tgz",
+      "integrity": "sha512-l0xWZpoPKpppFzMfvVyFmp9vLN7w/ZZJPefUicMCepfJeQ8sMcztloGYY9DfjVPo6tIUDzU5Hw3MUbIjj9AVVA==",
+      "dev": true,
       "requires": {
         "iterall": "^1.2.2"
       }
     },
     "graphql-extensions": {
-      "version": "0.11.0",
-      "resolved": "https://registry.npmjs.org/graphql-extensions/-/graphql-extensions-0.11.0.tgz",
-      "integrity": "sha512-zd4qfUiJoYBx2MwJusM36SEJ+YmJ1ki8YF8nlm9mgaPDUzsnmFq4lxULxUfhLAXFwZw7MbEN2vV4V6WiNgSJLg==",
-      "dev": true,
+      "version": "0.12.5",
+      "resolved": "https://registry.npmjs.org/graphql-extensions/-/graphql-extensions-0.12.5.tgz",
+      "integrity": "sha512-mGyGaktGpK3TVBtM0ZoyPX6Xk0mN9GYX9DRyFzDU4k4A2w93nLX7Ebcp+9/O5nHRmgrc0WziYYSmoWq2WNIoUQ==",
       "requires": {
         "@apollographql/apollo-tools": "^0.4.3",
-        "apollo-server-env": "^2.4.3",
-        "apollo-server-types": "^0.3.0"
+        "apollo-server-env": "^2.4.5",
+        "apollo-server-types": "^0.6.0"
       }
     },
     "graphql-subscriptions": {
@@ -4069,20 +3998,42 @@
       }
     },
     "graphql-tag": {
-      "version": "2.10.3",
-      "resolved": "https://registry.npmjs.org/graphql-tag/-/graphql-tag-2.10.3.tgz",
-      "integrity": "sha512-4FOv3ZKfA4WdOKJeHdz6B3F/vxBLSgmBcGeAFPf4n1F64ltJUvOOerNj0rsJxONQGdhUMynQIvd6LzB+1J5oKA=="
+      "version": "2.11.0",
+      "resolved": "https://registry.npmjs.org/graphql-tag/-/graphql-tag-2.11.0.tgz",
+      "integrity": "sha512-VmsD5pJqWJnQZMUeRwrDhfgoyqcfwEkvtpANqcoUG8/tOLkwNgU9mzub/Mc78OJMhHjx7gfAMTxzdG43VGg3bA=="
     },
     "graphql-tools": {
-      "version": "4.0.7",
-      "resolved": "https://registry.npmjs.org/graphql-tools/-/graphql-tools-4.0.7.tgz",
-      "integrity": "sha512-rApl8sT8t/W1uQRcwzxMYyUBiCl/XicluApiDkNze5TX/GR0BSTQMjM2UcRGdTmkbsb1Eqq6afkyyeG/zMxZYQ==",
+      "version": "4.0.8",
+      "resolved": "https://registry.npmjs.org/graphql-tools/-/graphql-tools-4.0.8.tgz",
+      "integrity": "sha512-MW+ioleBrwhRjalKjYaLQbr+920pHBgy9vM/n47sswtns8+96sRn5M/G+J1eu7IMeKWiN/9p6tmwCHU7552VJg==",
       "requires": {
-        "apollo-link": "^1.2.3",
+        "apollo-link": "^1.2.14",
         "apollo-utilities": "^1.0.1",
         "deprecated-decorator": "^0.1.6",
         "iterall": "^1.1.3",
         "uuid": "^3.1.0"
+      },
+      "dependencies": {
+        "apollo-link": {
+          "version": "1.2.14",
+          "resolved": "https://registry.npmjs.org/apollo-link/-/apollo-link-1.2.14.tgz",
+          "integrity": "sha512-p67CMEFP7kOG1JZ0ZkYZwRDa369w5PIjtMjvrQd/HnIV8FRsHRqLqK+oAZQnFa1DDdZtOtHTi+aMIW6EatC2jg==",
+          "requires": {
+            "apollo-utilities": "^1.3.0",
+            "ts-invariant": "^0.4.0",
+            "tslib": "^1.9.3",
+            "zen-observable-ts": "^0.8.21"
+          }
+        },
+        "zen-observable-ts": {
+          "version": "0.8.21",
+          "resolved": "https://registry.npmjs.org/zen-observable-ts/-/zen-observable-ts-0.8.21.tgz",
+          "integrity": "sha512-Yj3yXweRc8LdRMrCC8nIc4kkjWecPAUVh0TI0OUrWXx6aX790vLcDlWca6I4vsyCGH3LpWxq0dJRcMOFoVqmeg==",
+          "requires": {
+            "tslib": "^1.9.3",
+            "zen-observable": "^0.8.0"
+          }
+        }
       }
     },
     "graphql-upload": {
@@ -4195,6 +4146,11 @@
         "inherits": "^2.0.3",
         "minimalistic-assert": "^1.0.1"
       }
+    },
+    "hexoid": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/hexoid/-/hexoid-1.0.0.tgz",
+      "integrity": "sha512-QFLV0taWQOZtvIRIAdBChesmogZrtuXvVWsFHZTk2SU+anspqZ2vMnoLg7IE1+Uk16N19APic1BuF8bC8c2m5g=="
     },
     "hosted-git-info": {
       "version": "2.8.8",
@@ -5499,15 +5455,30 @@
       }
     },
     "light-my-request": {
-      "version": "3.8.0",
-      "resolved": "https://registry.npmjs.org/light-my-request/-/light-my-request-3.8.0.tgz",
-      "integrity": "sha512-cIOWmNsgoStysmkzcv2EwvLwMb2hEm6oqKMerG/b5ey9F0we2Qony8cAZgBktmGPYUvPyKsDCzMcYU6fXbpWew==",
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/light-my-request/-/light-my-request-4.1.0.tgz",
+      "integrity": "sha512-MweHfXZh1olI/7orXZ19WL1cpm7TyrKtvgSeBAC2jojJlMEqaDxb0VgvZ3azUHVqVVLffgdai43ty/E0Nhdgvw==",
       "dev": true,
       "requires": {
-        "ajv": "^6.10.2",
+        "ajv": "^6.12.2",
         "cookie": "^0.4.0",
-        "readable-stream": "^3.4.0",
+        "fastify-warning": "^0.2.0",
+        "readable-stream": "^3.6.0",
         "set-cookie-parser": "^2.4.1"
+      },
+      "dependencies": {
+        "ajv": {
+          "version": "6.12.5",
+          "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.12.5.tgz",
+          "integrity": "sha512-lRF8RORchjpKG50/WFf8xmg7sgCLFiYNNnqdKflk63whMQcWR5ngGjiSXkL9bjxy6B2npOK2HSMN49jEBMSkag==",
+          "dev": true,
+          "requires": {
+            "fast-deep-equal": "^3.1.1",
+            "fast-json-stable-stringify": "^2.0.0",
+            "json-schema-traverse": "^0.4.1",
+            "uri-js": "^4.2.2"
+          }
+        }
       }
     },
     "lines-and-columns": {
@@ -6024,9 +5995,9 @@
       }
     },
     "loglevel": {
-      "version": "1.6.8",
-      "resolved": "https://registry.npmjs.org/loglevel/-/loglevel-1.6.8.tgz",
-      "integrity": "sha512-bsU7+gc9AJ2SqpzxwU3+1fedl8zAntbtC5XYlt3s2j1hJcn2PsXSmgN8TaLG/J1/2mod4+cE/3vNL70/c1RNCA=="
+      "version": "1.7.0",
+      "resolved": "https://registry.npmjs.org/loglevel/-/loglevel-1.7.0.tgz",
+      "integrity": "sha512-i2sY04nal5jDcagM3FMfG++T69GEEM8CYuOfeOIvmXzOIcwE9a/CJPR0MFM97pYMj/u10lzz7/zd7+qwhrBTqQ=="
     },
     "long": {
       "version": "4.0.0",
@@ -6141,16 +6112,6 @@
         "regex-not": "^1.0.0",
         "snapdragon": "^0.8.1",
         "to-regex": "^3.0.2"
-      }
-    },
-    "middie": {
-      "version": "4.1.0",
-      "resolved": "https://registry.npmjs.org/middie/-/middie-4.1.0.tgz",
-      "integrity": "sha512-eylPpZA+K3xO9kpDjagoPkEUkNcWV3EAo5OEz0MqsekUpT7KbnQkk8HNZkh4phx2vvOAmNNZuLRWF9lDDHPpVQ==",
-      "dev": true,
-      "requires": {
-        "path-to-regexp": "^4.0.0",
-        "reusify": "^1.0.2"
       }
     },
     "mime": {
@@ -6285,9 +6246,9 @@
       "dev": true
     },
     "node-fetch": {
-      "version": "2.6.0",
-      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.6.0.tgz",
-      "integrity": "sha512-8dG4H5ujfvFiqDmVu9fQ5bOHUC15JMjMY/Zumv26oOvvVJjM67KF8koCWIabKQ1GJIa9r2mMZscBq/TbdOcmNA=="
+      "version": "2.6.1",
+      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.6.1.tgz",
+      "integrity": "sha512-V4aYg89jEoVRxRb2fJdAg8FHvI7cEyYdVAh94HH0UIK8oJxUfkjlDQN9RbMx+bEjP7+ggMiFRprSti032Oipxw=="
     },
     "node-int64": {
       "version": "0.4.0",
@@ -6465,7 +6426,6 @@
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
       "integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
-      "dev": true,
       "requires": {
         "wrappy": "1"
       }
@@ -6617,12 +6577,6 @@
       "integrity": "sha512-GSmOT2EbHrINBf9SR7CDELwlJ8AENk3Qn7OikK4nFYAu3Ote2+JYNVvkpAEQm3/TLNEJFD/xZJjzyxg3KBWOzw==",
       "dev": true
     },
-    "path-to-regexp": {
-      "version": "4.0.5",
-      "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-4.0.5.tgz",
-      "integrity": "sha512-l+fTaGG2N9ZRpCEUj5fG1VKdDLaiqwCIvPngpnxzREhcdobhZC4ou4w984HBu72DqAJ5CfcdV6tjqNOunfpdsQ==",
-      "dev": true
-    },
     "path-type": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/path-type/-/path-type-3.0.0.tgz",
@@ -6651,23 +6605,23 @@
       "dev": true
     },
     "pino": {
-      "version": "5.17.0",
-      "resolved": "https://registry.npmjs.org/pino/-/pino-5.17.0.tgz",
-      "integrity": "sha512-LqrqmRcJz8etUjyV0ddqB6OTUutCgQULPFg2b4dtijRHUsucaAdBgSUW58vY6RFSX+NT8963F+q0tM6lNwGShA==",
+      "version": "6.6.1",
+      "resolved": "https://registry.npmjs.org/pino/-/pino-6.6.1.tgz",
+      "integrity": "sha512-DOgm7rn6ctBkBYemHXSLj7+j3o3U1q1FWBXbHcprur8mA93QcJSycEkEqhqKiFB9Mx/3Qld2FGr6+9yfQza0kA==",
       "dev": true,
       "requires": {
         "fast-redact": "^2.0.0",
         "fast-safe-stringify": "^2.0.7",
         "flatstr": "^1.0.12",
         "pino-std-serializers": "^2.4.2",
-        "quick-format-unescaped": "^3.0.3",
-        "sonic-boom": "^0.7.5"
+        "quick-format-unescaped": "^4.0.1",
+        "sonic-boom": "^1.0.2"
       }
     },
     "pino-std-serializers": {
-      "version": "2.4.2",
-      "resolved": "https://registry.npmjs.org/pino-std-serializers/-/pino-std-serializers-2.4.2.tgz",
-      "integrity": "sha512-WaL504dO8eGs+vrK+j4BuQQq6GLKeCCcHaMB2ItygzVURcL1CycwNEUHTD/lHFHs/NL5qAz2UKrjYWXKSf4aMQ==",
+      "version": "2.5.0",
+      "resolved": "https://registry.npmjs.org/pino-std-serializers/-/pino-std-serializers-2.5.0.tgz",
+      "integrity": "sha512-wXqbqSrIhE58TdrxxlfLwU9eDhrzppQDvGhBEr1gYbzzM4KKo3Y63gSjiDXRKLVS2UOXdPNR2v+KnQgNrs+xUg==",
       "dev": true
     },
     "pirates": {
@@ -6802,10 +6756,16 @@
       "integrity": "sha512-N5ZAX4/LxJmF+7wN74pUD6qAh9/wnvdQcjq9TZjevvXzSUo7bfmw91saqMjzGS2xq91/odN2dW/WOl7qQHNDGA==",
       "dev": true
     },
+    "queue-microtask": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/queue-microtask/-/queue-microtask-1.1.4.tgz",
+      "integrity": "sha512-eY/4Obve9cE5FK8YvC1cJsm5cr7XvAurul8UtBDJ2PR1p5NmAwHtvAt5ftcLtwYRCUKNhxCneZZlxmUDFoSeKA==",
+      "dev": true
+    },
     "quick-format-unescaped": {
-      "version": "3.0.3",
-      "resolved": "https://registry.npmjs.org/quick-format-unescaped/-/quick-format-unescaped-3.0.3.tgz",
-      "integrity": "sha512-dy1yjycmn9blucmJLXOfZDx1ikZJUi6E8bBZLnhPG5gBrVhHXx2xVyqqgKBubVNEXmx51dBACMHpoMQK/N/AXQ==",
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/quick-format-unescaped/-/quick-format-unescaped-4.0.1.tgz",
+      "integrity": "sha512-RyYpQ6Q5/drsJyOhrWHYMWTedvjTIat+FTwv0K4yoUxzvekw2aRHMQJLlnvt8UantkZg2++bEzD9EdxXqkWf4A==",
       "dev": true
     },
     "range-parser": {
@@ -7479,9 +7439,9 @@
       }
     },
     "sonic-boom": {
-      "version": "0.7.7",
-      "resolved": "https://registry.npmjs.org/sonic-boom/-/sonic-boom-0.7.7.tgz",
-      "integrity": "sha512-Ei5YOo5J64GKClHIL/5evJPgASXFVpfVYbJV9PILZQytTK6/LCwHvsZJW2Ig4p9FMC2OrBrMnXKgRN/OEoAWfg==",
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/sonic-boom/-/sonic-boom-1.3.0.tgz",
+      "integrity": "sha512-4nX6OYvOYr6R76xfQKi6cZpTO3YSWe/vd+QdIfoH0lBy0MnPkeAbb2rRWgmgADkXUeCKPwO1FZAKlAVWAadELw==",
       "dev": true,
       "requires": {
         "atomic-sleep": "^1.0.0",
@@ -7625,6 +7585,11 @@
       "integrity": "sha1-NbCYdbT/SfJqd35QmzCQoyJr8ks=",
       "dev": true
     },
+    "stream-wormhole": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/stream-wormhole/-/stream-wormhole-1.1.0.tgz",
+      "integrity": "sha512-gHFfL3px0Kctd6Po0M8TzEvt3De/xu6cnRrjlfYNhwbhLPLwigI2t1nc6jrzNuaYg5C4YF78PPFuQPzRiqn9ew=="
+    },
     "streamsearch": {
       "version": "0.1.2",
       "resolved": "https://registry.npmjs.org/streamsearch/-/streamsearch-0.1.2.tgz",
@@ -7752,9 +7717,9 @@
       "dev": true
     },
     "subscriptions-transport-ws": {
-      "version": "0.9.16",
-      "resolved": "https://registry.npmjs.org/subscriptions-transport-ws/-/subscriptions-transport-ws-0.9.16.tgz",
-      "integrity": "sha512-pQdoU7nC+EpStXnCfh/+ho0zE0Z+ma+i7xvj7bkXKb1dvYHSZxgRPaU6spRP+Bjzow67c/rRDoix5RT0uU9omw==",
+      "version": "0.9.18",
+      "resolved": "https://registry.npmjs.org/subscriptions-transport-ws/-/subscriptions-transport-ws-0.9.18.tgz",
+      "integrity": "sha512-tztzcBTNoEbuErsVQpTN2xUNN/efAZXyCyL5m3x4t6SKrEiTL2N8SaKWBFWM4u56pL79ULif3zjyeq+oV+nOaA==",
       "requires": {
         "backo2": "^1.0.2",
         "eventemitter3": "^3.1.0",
@@ -7791,6 +7756,17 @@
         "readable-stream": "^2.3.5"
       },
       "dependencies": {
+        "form-data": {
+          "version": "2.5.1",
+          "resolved": "https://registry.npmjs.org/form-data/-/form-data-2.5.1.tgz",
+          "integrity": "sha512-m21N3WOmEEURgk6B9GLOE4RuWOFf28Lhh9qGYeNlGq4VDXUlJy2th2slBNU8Gp8EzloYZOibZJ7t5ecIrFSjVA==",
+          "dev": true,
+          "requires": {
+            "asynckit": "^0.4.0",
+            "combined-stream": "^1.0.6",
+            "mime-types": "^2.1.12"
+          }
+        },
         "readable-stream": {
           "version": "2.3.7",
           "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.7.tgz",
@@ -8086,9 +8062,9 @@
       }
     },
     "typescript": {
-      "version": "3.8.3",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-3.8.3.tgz",
-      "integrity": "sha512-MYlEfn5VrLNsgudQTVJeNaQFUAI7DkhnOjdpAp4T+ku1TfQClewlbSuTVHiA+8skNBgaf02TL/kLOvig4y3G8w==",
+      "version": "3.9.7",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-3.9.7.tgz",
+      "integrity": "sha512-BLbiRkiBzAwsjut4x/dsibSTB6yWpwT5qWmC2OfuCg3GgVQCSgMs4vEctYPhsaGtd0AeuuHMkjZ2h2WG8MSzRw==",
       "dev": true
     },
     "union-value": {
@@ -8327,8 +8303,7 @@
     "wrappy": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
-      "integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8=",
-      "dev": true
+      "integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8="
     },
     "write": {
       "version": "1.0.3",
@@ -8363,6 +8338,22 @@
       "resolved": "https://registry.npmjs.org/xml-name-validator/-/xml-name-validator-3.0.0.tgz",
       "integrity": "sha512-A5CUptxDsvxKJEU3yO6DuWBSJz/qizqzJKOMIfUJHETbBw/sFaDxgd6fxm1ewUaM0jZ444Fc5vC5ROYurg/4Pw==",
       "dev": true
+    },
+    "xss": {
+      "version": "1.0.8",
+      "resolved": "https://registry.npmjs.org/xss/-/xss-1.0.8.tgz",
+      "integrity": "sha512-3MgPdaXV8rfQ/pNn16Eio6VXYPTkqwa0vc7GkiymmY/DqR1SE/7VPAAVZz1GJsJFrllMYO3RHfEaiUGjab6TNw==",
+      "requires": {
+        "commander": "^2.20.3",
+        "cssfilter": "0.0.10"
+      },
+      "dependencies": {
+        "commander": {
+          "version": "2.20.3",
+          "resolved": "https://registry.npmjs.org/commander/-/commander-2.20.3.tgz",
+          "integrity": "sha512-GpVkmM8vF2vQUkj2LvZmD35JxeJOLCwJ9cUkugyk2nuhbv3+mJvpLYYt+0+USMxE+oj+ey/lJEnhZw75x/OMcQ=="
+        }
+      }
     },
     "y18n": {
       "version": "4.0.0",
@@ -8418,9 +8409,10 @@
       "integrity": "sha512-PQ2PC7R9rslx84ndNBZB/Dkv8V8fZEpk83RLgXtYd0fwUgEjseMn1Dgajh2x6S8QbZAFa9p2qVCEuYZNgve0dQ=="
     },
     "zen-observable-ts": {
-      "version": "0.8.20",
-      "resolved": "https://registry.npmjs.org/zen-observable-ts/-/zen-observable-ts-0.8.20.tgz",
-      "integrity": "sha512-2rkjiPALhOtRaDX6pWyNqK1fnP5KkJJybYebopNSn6wDG1lxBoFs2+nwwXKoA6glHIrtwrfBBy6da0stkKtTAA==",
+      "version": "0.8.21",
+      "resolved": "https://registry.npmjs.org/zen-observable-ts/-/zen-observable-ts-0.8.21.tgz",
+      "integrity": "sha512-Yj3yXweRc8LdRMrCC8nIc4kkjWecPAUVh0TI0OUrWXx6aX790vLcDlWca6I4vsyCGH3LpWxq0dJRcMOFoVqmeg==",
+      "dev": true,
       "requires": {
         "tslib": "^1.9.3",
         "zen-observable": "^0.8.0"

--- a/package.json
+++ b/package.json
@@ -17,38 +17,42 @@
     "compile": "tsc --build tsconfig.json",
     "compile:clean": "tsc --build tsconfig.json --clean",
     "lint": "eslint '**/**'",
-    "test": "jest",
+    "test": "jest --verbose",
+    "test:clean": "jest --clearCache",
+    "test:watch": "jest --verbose --watchAll",
     "watch": "tsc --build tsconfig.json --watch"
   },
   "dependencies": {
-    "@apollographql/graphql-playground-html": "1.6.24",
-    "apollo-server-core": "2.14.2",
-    "apollo-server-types": "0.3.0",
-    "fastify-accepts": "^1.0.0",
-    "fastify-cors": "^3.0.3",
-    "graphql-subscriptions": "^1.0.0",
-    "graphql-tools": "^4.0.0"
+    "@apollographql/graphql-playground-html": "^1.6.26",
+    "apollo-server-core": "^2.18.1",
+    "apollo-server-types": "^0.6.0",
+    "fastify-accepts": "^2.0.1",
+    "fastify-cors": "^4.1.0",
+    "fastify-multipart": "^3.2.0",
+    "graphql-subscriptions": "^1.1.0",
+    "graphql-tools": "^4.0.8"
   },
   "devDependencies": {
     "@types/jest": "24.9.1",
-    "@types/node": "8.10.59",
+    "@types/node": "12.12.62",
     "@typescript-eslint/eslint-plugin": "^2.25.0",
     "@typescript-eslint/parser": "^2.25.0",
-    "apollo-datasource-rest": "^0.8.0",
-    "apollo-engine-reporting-protobuf": "^0.4.4",
+    "apollo-datasource-rest": "^0.9.4",
     "apollo-fetch": "^0.7.0",
-    "apollo-link": "^1.2.13",
-    "apollo-link-http": "^1.5.16",
+    "apollo-link": "^1.2.14",
+    "apollo-link-http": "^1.5.17",
     "apollo-link-persisted-queries": "^0.2.2",
-    "apollo-server-plugin-response-cache": "^0.4.0",
+    "apollo-reporting-protobuf": "^0.6.0",
+    "apollo-server-plugin-response-cache": "^0.5.5",
     "body-parser": "^1.19.0",
     "eslint": "^6.8.0",
     "eslint-config-prettier": "^6.10.1",
     "eslint-plugin-prettier": "^3.1.2",
     "express": "^4.17.1",
-    "fastify": "^2.14.1",
-    "form-data": "2.5.1",
-    "graphql": "14.6.0",
+    "fastify": "^3.5.0",
+    "form-data": "^3.0.0",
+    "graphql": "^14.7.0",
+    "graphql-extensions": "^0.12.5",
     "husky": "^4.2.3",
     "jest": "24.9.0",
     "jest-config": "24.9.0",
@@ -57,10 +61,10 @@
     "prettier": "1.19.1",
     "supertest": "^4.0.2",
     "ts-jest": "24.3.0",
-    "typescript": "3.8.3"
+    "typescript": "3.9.7"
   },
   "peerDependencies": {
-    "graphql": "^0.12.0 || ^0.13.0 || ^14.0.0 || ^15.0.0-rc.2"
+    "graphql": "^0.12.0 || ^0.13.0 || ^14.0.0 || ^15.0.0"
   },
   "lint-staged": {
     "*": [

--- a/src/fastifyApollo.ts
+++ b/src/fastifyApollo.ts
@@ -3,31 +3,33 @@ import {
   GraphQLOptions,
   runHttpQuery,
 } from 'apollo-server-core';
-import { FastifyReply, FastifyRequest, RequestHandler } from 'fastify';
-import { IncomingMessage, OutgoingMessage } from 'http';
+import { FastifyReply, FastifyRequest, RouteHandlerMethod } from 'fastify';
 import { ValueOrPromise } from 'apollo-server-types';
 
 export async function graphqlFastify(
   options: (
-    req?: FastifyRequest<IncomingMessage>,
-    res?: FastifyReply<OutgoingMessage>,
+    request?: FastifyRequest,
+    reply?: FastifyReply,
   ) => ValueOrPromise<GraphQLOptions>,
-): Promise<RequestHandler<IncomingMessage, OutgoingMessage>> {
+): Promise<RouteHandlerMethod> {
   if (!options) {
     throw new Error('Apollo Server requires options.');
   }
 
   return async (
-    request: FastifyRequest<IncomingMessage>,
-    reply: FastifyReply<OutgoingMessage>,
-  ) => {
+    request: FastifyRequest,
+    reply: FastifyReply,
+  ): Promise<void> => {
     try {
       const { graphqlResponse, responseInit } = await runHttpQuery(
         [request, reply],
         {
-          method: request.req.method as string,
+          method: request.raw.method as string,
           options,
-          query: request.req.method === 'POST' ? request.body : request.query,
+          query:
+            request.raw.method === 'POST'
+              ? (request.body as any)
+              : (request.query as any),
           request: convertNodeHttpToRequest(request.raw),
         },
       );


### PR DESCRIPTION
### Summary
- Update Apollo deps.
- Update Apollo tests: 
  - https://github.com/apollographql/apollo-server/blob/main/packages/apollo-server-fastify/src/__tests__/ApolloServer.test.ts
  - https://github.com/apollographql/apollo-server/blob/main/packages/apollo-server-integration-testsuite/src/ApolloServer.ts
  - https://github.com/apollographql/apollo-server/blob/main/packages/apollo-server-integration-testsuite/src/index.ts
- Update fastify and fastify deps. (No more v2 compatability)
- Use fastify-multipart for parsing file uploads (fixed failing upload file tests).
- Resolve all fastify deprecation warnings.